### PR TITLE
fix: remove stray double dot in saucer KickForceVar assignment

### DIFF
--- a/Nitro Ground Shaker (Bally 1980) 1.0.0hf5.vbs
+++ b/Nitro Ground Shaker (Bally 1980) 1.0.0hf5.vbs
@@ -133,7 +133,7 @@ Sub table1_Init
     bssaucer2.InitSaucer Kicker2, 32, 190, 15
     bsSaucer2.InitExitSnd SoundFX("fx_kicker", DOFContactors), SoundFX("fx_Solenoid", DOFContactors)
     bssaucer2.KickAngleVar = 10
-    bssaucer2..KickForceVar = 3
+    bssaucer2.KickForceVar = 3
 
     ' Drop targets
     set dtbank = new cvpmdroptarget

--- a/Pinball (Stern 1977).vbs
+++ b/Pinball (Stern 1977).vbs
@@ -581,7 +581,7 @@ Sub Table1_Init
         bsSaucer1.InitSaucer SW13,13,135,18
         bsSaucer1.InitExitSnd SoundFX("Popper",DOFContactors), SoundFX("Solenoid",DOFContactors)
         bsSaucer1.KickAngleVar=10
-        bsSaucer1..KickForceVar = 3
+        bsSaucer1.KickForceVar = 3
 
 End Sub
 


### PR DESCRIPTION
The double dot (bsSaucer1..KickForceVar) is a syntax error rejected by the VBScript compiler. Fixed in:
- Pinball (Stern 1977).vbs
- Nitro Ground Shaker (Bally 1980) 1.0.0hf5.vbs