### PR TITLE
fix: restore missing SoundFX argument and closing paren in Robo-War bumpers

### DIFF
--- a/Robo-War (Gottlieb 1988).vbs
+++ b/Robo-War (Gottlieb 1988).vbs
@@ -226,9 +226,9 @@ Sub LeftSlingShot_Timer
 End Sub
 
 ' Bumpers
-Sub Bumper1_Hit:PlaySoundAtVol SoundFX("Bumper", ActiveBall, 1:vpmTimer.PulseSw 53:End Sub
-Sub Bumper2_Hit:PlaySoundAtVol SoundFX("Bumper", ActiveBall, 1:vpmTimer.PulseSw 63:End Sub
-Sub Bumper3_Hit:PlaySoundAtVol SoundFX("Bumper", ActiveBall, 1:vpmTimer.PulseSw 73:End Sub
+Sub Bumper1_Hit:PlaySoundAtVol SoundFX("Bumper", DOFContactors), ActiveBall, 1:vpmTimer.PulseSw 53:End Sub
+Sub Bumper2_Hit:PlaySoundAtVol SoundFX("Bumper", DOFContactors), ActiveBall, 1:vpmTimer.PulseSw 63:End Sub
+Sub Bumper3_Hit:PlaySoundAtVol SoundFX("Bumper", DOFContactors), ActiveBall, 1:vpmTimer.PulseSw 73:End Sub
 ' Drain
 Sub Drain_Hit:PlaySoundAtVol "Drain": Drain, 1:End Sub
 ' Rollovers


### PR DESCRIPTION
The Bumper1/2/3_Hit subs called SoundFX("Bumper", ActiveBall, 1 with the DOFEvent argument and closing parenthesis dropped, which the VBScript compiler rejects. Restored to the standard form used elsewhere in the corpus: SoundFX("Bumper", DOFContactors), ActiveBall, 1